### PR TITLE
Fix: Cross-platform compatibility for relative path tests

### DIFF
--- a/tests/unit/test_tracker_relative_paths.py
+++ b/tests/unit/test_tracker_relative_paths.py
@@ -40,7 +40,9 @@ class TestRelativePathStorage:
         # Verify path is relative in JSON
         assert len(data) == 1
         saved_path = data[0]["installed_path"]
-        assert saved_path == ".github/instructions/test.md"
+        # Normalize for cross-platform comparison (Windows uses backslashes)
+        normalized_path = Path(saved_path).as_posix()
+        assert normalized_path == ".github/instructions/test.md"
         assert not Path(saved_path).is_absolute()
 
     def test_project_installation_no_project_root_field(self, temp_dir: Path):
@@ -75,7 +77,8 @@ class TestRelativePathStorage:
         tracker_file = temp_dir / "installations.json"
         tracker = InstallationTracker(tracker_file)
 
-        absolute_path = "/Users/test/.cursor/rules/global.mdc"
+        # Use temp_dir to create a truly absolute path that works on all platforms
+        absolute_path = str(temp_dir / ".cursor" / "rules" / "global.mdc")
         record = InstallationRecord(
             instruction_name="global-instruction",
             ai_tool=AIToolType.CURSOR,
@@ -247,7 +250,9 @@ class TestBackwardCompatibility:
             data = json.load(f)
 
         # Should now be in new format
-        assert data[0]["installed_path"] == ".github/instructions/test.md"
+        # Normalize for cross-platform comparison (Windows uses backslashes)
+        normalized_path = Path(data[0]["installed_path"]).as_posix()
+        assert normalized_path == ".github/instructions/test.md"
         assert "project_root" not in data[0]
 
     def test_mixed_old_and_new_format(self, temp_dir: Path):


### PR DESCRIPTION
## Overview

Fixes failing Windows CI tests in `test_tracker_relative_paths.py`.

## Problem

Tests were failing on Windows due to path separator differences:
- Unix systems use forward slashes: `.github/instructions/test.md`
- Windows uses backslashes: `.github\instructions\test.md`
- Unix-style absolute paths like `/Users/test/...` aren't recognized as absolute on Windows

## Solution

1. **Normalize path separators**: Use `Path.as_posix()` to convert paths to forward slashes for cross-platform assertions
2. **Use platform-agnostic absolute paths**: Use `temp_dir` to create truly absolute paths that work on all platforms instead of hardcoded Unix paths

## Changes

- `test_project_installation_saves_relative_path`: Normalize path before assertion
- `test_global_installation_keeps_absolute_path`: Use temp_dir for absolute path
- `test_migrating_old_format_on_save`: Normalize path before assertion

## Testing

✅ All 8 tests pass locally on macOS
✅ Should fix Windows CI failures

Closes #5