### PR TITLE
feat: add Kiro IDE support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-02-13
+
+### Added
+- **Kiro IDE Support** - Added support for Amazon's Kiro AI-powered IDE (#29)
+  - Instructions installed to `.kiro/steering/*.md`
+  - Cross-platform detection (macOS, Linux, Windows)
+  - Package system support for instructions and resources
+  - IDE capability registry entry for Kiro
+  - Component detector recognizes `.kiro/steering/` directories
+
 ## [0.5.0] - 2026-01-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Core Concepts
 
 1. **Library System**: Instructions are downloaded from Git repos or local folders to `~/.ai-config-kit/library/` organized by namespace
-2. **Project-Level Installation**: All installations are project-specific, stored in tool-specific directories (`.cursor/rules/`, `.claude/rules/`, etc.)
+2. **Project-Level Installation**: All installations are project-specific, stored in tool-specific directories (`.cursor/rules/`, `.claude/rules/`, `.kiro/steering/`, etc.)
 3. **Installation Tracking**: Tracked in `<project-root>/.ai-config-kit/installations.json` for each project (instructions) and `<project-root>/.ai-config-kit/packages.json` for packages
 4. **Interactive TUI**: Terminal UI for browsing and selecting instructions from the library
 5. **Configuration Packages**: Multi-component packages containing instructions, MCP servers, hooks, commands, and resources that can be installed as a unit
@@ -26,6 +26,7 @@ ai-config-kit/
 │   ├── base.py       # Abstract AITool base class
 │   ├── claude.py     # Claude Code (.claude/rules/*.md)
 │   ├── cursor.py     # Cursor (.cursor/rules/*.mdc)
+│   ├── kiro.py       # Kiro (.kiro/steering/*.md)
 │   ├── winsurf.py    # Windsurf (.windsurf/rules/*.md)
 │   ├── copilot.py    # GitHub Copilot (.github/instructions/*.md)
 │   └── detector.py   # Tool detection logic
@@ -392,6 +393,7 @@ aiconfig package uninstall package-name --yes
 Different IDEs support different component types:
 - **Claude Code**: All components (instructions, MCP, hooks, commands, resources)
 - **Cursor**: Instructions and resources only
+- **Kiro**: Instructions and resources only
 - **Windsurf**: Instructions and resources only
 - **GitHub Copilot**: Instructions only
 
@@ -401,6 +403,7 @@ Unsupported components are automatically skipped and counted separately.
 Components are translated to IDE-specific formats:
 - **Claude Code**: `.md` files in `.claude/rules/`, `.claude/hooks/`, `.claude/commands/`
 - **Cursor**: `.mdc` files in `.cursor/rules/`
+- **Kiro**: `.md` files in `.kiro/steering/`
 - **Windsurf**: `.md` files in `.windsurf/rules/`
 - **GitHub Copilot**: `.md` files in `.github/instructions/`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Works with:** Claude Code • Claude Desktop • Cursor • GitHub Copilot • Windsurf
+**Works with:** Claude Code • Claude Desktop • Cursor • GitHub Copilot • Kiro • Windsurf
 
 </div>
 
@@ -258,16 +258,16 @@ Any IDE-specific content from Git repositories:
 
 Complete configuration bundles with multiple component types:
 
-| Component | Claude | Cursor | Windsurf | Copilot |
-|-----------|--------|--------|----------|---------|
-| Instructions | `.claude/rules/` | `.cursor/rules/` | `.windsurf/rules/` | `.github/instructions/` |
-| MCP Servers | ✅ | ✅ | ✅ | ✅ |
-| Hooks | ✅ | ❌ | ❌ | ❌ |
-| Commands | ✅ | ❌ | ❌ | ❌ |
-| Skills | ✅ | ❌ | ❌ | ❌ |
-| Workflows | ❌ | ❌ | ✅ | ❌ |
-| Memory Files | ✅ (CLAUDE.md) | ❌ | ❌ | ❌ |
-| Resources | ✅ | ✅ | ✅ | ❌ |
+| Component | Claude | Cursor | Kiro | Windsurf | Copilot |
+|-----------|--------|--------|------|----------|---------|
+| Instructions | `.claude/rules/` | `.cursor/rules/` | `.kiro/steering/` | `.windsurf/rules/` | `.github/instructions/` |
+| MCP Servers | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Hooks | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Commands | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Skills | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Workflows | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Memory Files | ✅ (CLAUDE.md) | ❌ | ❌ | ❌ | ❌ |
+| Resources | ✅ | ✅ | ✅ | ✅ | ❌ |
 
 ### MCP Server Configurations
 
@@ -287,7 +287,7 @@ Model Context Protocol server setups for enhanced AI capabilities:
 
 - Python 3.10 or higher
 - Git (for cloning template repositories)
-- One of: Claude Code, Claude Desktop, Cursor, GitHub Copilot, or Windsurf
+- One of: Claude Code, Claude Desktop, Cursor, GitHub Copilot, Kiro, or Windsurf
 
 ### Install AI Config Kit
 

--- a/aiconfigkit/ai_tools/base.py
+++ b/aiconfigkit/ai_tools/base.py
@@ -12,7 +12,7 @@ class AITool(ABC):
     """
     Abstract base class for AI coding tool integrations.
 
-    Each AI tool (Cursor, Copilot, Winsurf, Claude) implements this interface
+    Each AI tool (Cursor, Copilot, Kiro, Winsurf, Claude) implements this interface
     to provide tool-specific installation logic.
     """
 

--- a/aiconfigkit/ai_tools/capability_registry.py
+++ b/aiconfigkit/ai_tools/capability_registry.py
@@ -121,6 +121,27 @@ CAPABILITY_REGISTRY: dict[AIToolType, IDECapability] = {
             "Supports workflows in .windsurf/workflows/. Limit of 100 MCP tools."
         ),
     ),
+    AIToolType.KIRO: IDECapability(
+        tool_type=AIToolType.KIRO,
+        tool_name="Kiro",
+        supported_components={
+            ComponentType.INSTRUCTION,
+            ComponentType.RESOURCE,
+        },
+        instructions_directory=".kiro/steering/",
+        instruction_file_extension=".md",
+        supports_project_scope=True,
+        supports_global_scope=False,
+        mcp_config_path=None,  # Kiro uses .kiro/settings/mcp.json but not yet supported
+        mcp_project_config_path=None,
+        hooks_directory=None,  # Kiro hooks use .kiro.hook JSON format, not yet supported
+        commands_directory=None,
+        notes=(
+            "Kiro uses .md files in .kiro/steering/ with optional YAML front matter "
+            "for inclusion modes (always, fileMatch, manual, auto). "
+            "MCP and hooks support deferred to future release."
+        ),
+    ),
     AIToolType.COPILOT: IDECapability(
         tool_type=AIToolType.COPILOT,
         tool_name="GitHub Copilot",

--- a/aiconfigkit/ai_tools/detector.py
+++ b/aiconfigkit/ai_tools/detector.py
@@ -6,6 +6,7 @@ from aiconfigkit.ai_tools.base import AITool
 from aiconfigkit.ai_tools.claude import ClaudeTool
 from aiconfigkit.ai_tools.copilot import CopilotTool
 from aiconfigkit.ai_tools.cursor import CursorTool
+from aiconfigkit.ai_tools.kiro import KiroTool
 from aiconfigkit.ai_tools.winsurf import WinsurfTool
 from aiconfigkit.core.models import AIToolType
 
@@ -20,6 +21,7 @@ class AIToolDetector:
             AIToolType.COPILOT: CopilotTool(),
             AIToolType.WINSURF: WinsurfTool(),
             AIToolType.CLAUDE: ClaudeTool(),
+            AIToolType.KIRO: KiroTool(),
         }
 
     def detect_installed_tools(self) -> list[AITool]:
@@ -78,6 +80,7 @@ class AIToolDetector:
             AIToolType.COPILOT,
             AIToolType.WINSURF,
             AIToolType.CLAUDE,
+            AIToolType.KIRO,
         ]
 
         for tool_type in priority:

--- a/aiconfigkit/ai_tools/kiro.py
+++ b/aiconfigkit/ai_tools/kiro.py
@@ -1,0 +1,85 @@
+"""Kiro AI tool integration."""
+
+from pathlib import Path
+
+from aiconfigkit.ai_tools.base import AITool
+from aiconfigkit.core.models import AIToolType
+from aiconfigkit.utils.paths import get_kiro_config_dir
+
+
+class KiroTool(AITool):
+    """Integration for Kiro AI coding tool."""
+
+    @property
+    def tool_type(self) -> AIToolType:
+        """Return the AI tool type identifier."""
+        return AIToolType.KIRO
+
+    @property
+    def tool_name(self) -> str:
+        """Return human-readable tool name."""
+        return "Kiro"
+
+    def is_installed(self) -> bool:
+        """
+        Check if Kiro is installed on the system.
+
+        Checks for existence of Kiro configuration directory.
+
+        Returns:
+            True if Kiro is detected
+        """
+        try:
+            config_dir = get_kiro_config_dir()
+            # Check if parent directory exists
+            # Kiro config dir structure: .../Kiro/User/globalStorage
+            kiro_base = config_dir.parent.parent
+            return kiro_base.exists()
+        except Exception:
+            return False
+
+    def get_instructions_directory(self) -> Path:
+        """
+        Get the directory where Kiro instructions should be installed.
+
+        Note: Kiro uses ~/.kiro/steering/ for global steering files.
+        This tool currently only supports project-level installations.
+
+        Returns:
+            Path to Kiro instructions directory
+
+        Raises:
+            NotImplementedError: Global installation not supported for Kiro
+        """
+        raise NotImplementedError(
+            f"{self.tool_name} global installation is not supported. "
+            "Please use project-level installation instead (--scope project)."
+        )
+
+    def get_instruction_file_extension(self) -> str:
+        """
+        Get the file extension for Kiro instructions.
+
+        Kiro uses markdown (.md) files for steering.
+
+        Returns:
+            File extension including the dot
+        """
+        return ".md"
+
+    def get_project_instructions_directory(self, project_root: Path) -> Path:
+        """
+        Get the directory for project-specific Kiro instructions.
+
+        Kiro stores project-specific steering files in .kiro/steering/ directory
+        in the project root. It supports multiple .md files in this directory.
+
+        Args:
+            project_root: Path to the project root directory
+
+        Returns:
+            Path to project instructions directory (.kiro/steering/)
+        """
+        instructions_dir = project_root / ".kiro" / "steering"
+        instructions_dir.mkdir(parents=True, exist_ok=True)
+        return instructions_dir

--- a/aiconfigkit/core/component_detector.py
+++ b/aiconfigkit/core/component_detector.py
@@ -232,6 +232,7 @@ class ComponentDetector:
         ".claude/rules": "claude",
         ".cursor/rules": "cursor",
         ".windsurf/rules": "windsurf",
+        ".kiro/steering": "kiro",
         ".github/instructions": "copilot",
     }
 

--- a/aiconfigkit/core/models.py
+++ b/aiconfigkit/core/models.py
@@ -13,6 +13,7 @@ class AIToolType(Enum):
     COPILOT = "copilot"
     WINSURF = "winsurf"
     CLAUDE = "claude"
+    KIRO = "kiro"
 
 
 class ConflictResolution(Enum):
@@ -403,7 +404,7 @@ class TemplateFile:
 
     Attributes:
         path: Relative path from repository root
-        ide: Target IDE ("all", "cursor", "claude", "windsurf", "copilot")
+        ide: Target IDE ("all", "cursor", "claude", "windsurf", "copilot", "kiro")
     """
 
     path: str
@@ -413,7 +414,7 @@ class TemplateFile:
         """Validate template file data."""
         if not self.path:
             raise ValueError("Template file path cannot be empty")
-        valid_ides = ["all", "cursor", "claude", "windsurf", "copilot"]
+        valid_ides = ["all", "cursor", "claude", "windsurf", "copilot", "kiro"]
         if self.ide not in valid_ides:
             raise ValueError(f"Invalid IDE type: {self.ide}. Must be one of {valid_ides}")
 

--- a/aiconfigkit/utils/paths.py
+++ b/aiconfigkit/utils/paths.py
@@ -55,6 +55,21 @@ def get_winsurf_config_dir() -> Path:
     raise OSError(f"Unsupported operating system: {os.name}")
 
 
+def get_kiro_config_dir() -> Path:
+    """Get Kiro configuration directory based on platform."""
+    home = get_home_directory()
+
+    if os.name == "nt":  # Windows
+        return home / "AppData" / "Roaming" / "Kiro" / "User" / "globalStorage"
+    elif os.name == "posix":
+        if "darwin" in os.uname().sysname.lower():  # macOS
+            return home / "Library" / "Application Support" / "Kiro" / "User" / "globalStorage"
+        else:  # Linux
+            return home / ".config" / "Kiro" / "User" / "globalStorage"
+
+    raise OSError(f"Unsupported operating system: {os.name}")
+
+
 def get_claude_config_dir() -> Path:
     """Get Claude Code configuration directory based on platform."""
     home = get_home_directory()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ai-config-kit"
-version = "0.5.0"
+version = "0.5.1"
 description = "Distribute and sync AI coding assistant configurations across teams"
 readme = "README.md"
 authors = [{ name = "Troy Larson", email = "troy@calvinware.com" }]
 requires-python = ">=3.10"
 license = { text = "MIT License" }
-keywords = ["cli", "ai", "config", "mcp", "cursor", "copilot", "claude", "windsurf"]
+keywords = ["cli", "ai", "config", "mcp", "cursor", "copilot", "claude", "kiro", "windsurf"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/tests/unit/packages/test_capability_registry.py
+++ b/tests/unit/packages/test_capability_registry.py
@@ -67,6 +67,7 @@ class TestCapabilityRegistry:
         assert AIToolType.CLAUDE in CAPABILITY_REGISTRY
         assert AIToolType.WINSURF in CAPABILITY_REGISTRY
         assert AIToolType.COPILOT in CAPABILITY_REGISTRY
+        assert AIToolType.KIRO in CAPABILITY_REGISTRY
 
     def test_cursor_capabilities(self) -> None:
         """Test Cursor IDE capabilities."""
@@ -175,16 +176,38 @@ class TestCapabilityRegistry:
             # Use a value that's not in the registry
             get_capability("INVALID_TOOL")  # type: ignore
 
+    def test_kiro_capabilities(self) -> None:
+        """Test Kiro IDE capabilities."""
+        kiro = CAPABILITY_REGISTRY[AIToolType.KIRO]
+
+        assert kiro.tool_type == AIToolType.KIRO
+        assert kiro.tool_name == "Kiro"
+        assert kiro.instructions_directory == ".kiro/steering/"
+        assert kiro.instruction_file_extension == ".md"
+        assert kiro.supports_project_scope
+        assert not kiro.supports_global_scope
+
+        # Kiro supports instructions and resources
+        assert kiro.supports_component(ComponentType.INSTRUCTION)
+        assert kiro.supports_component(ComponentType.RESOURCE)
+
+        # Kiro does not support hooks, commands, MCP, or skills (yet)
+        assert not kiro.supports_component(ComponentType.HOOK)
+        assert not kiro.supports_component(ComponentType.COMMAND)
+        assert not kiro.supports_component(ComponentType.MCP_SERVER)
+        assert not kiro.supports_component(ComponentType.SKILL)
+
     def test_get_supported_tools_for_instruction(self) -> None:
         """Test getting tools that support instructions."""
         tools = get_supported_tools_for_component(ComponentType.INSTRUCTION)
 
         # All tools support instructions
-        assert len(tools) == 4
+        assert len(tools) == 5
         assert AIToolType.CURSOR in tools
         assert AIToolType.CLAUDE in tools
         assert AIToolType.WINSURF in tools
         assert AIToolType.COPILOT in tools
+        assert AIToolType.KIRO in tools
 
     def test_get_supported_tools_for_mcp_server(self) -> None:
         """Test getting tools that support MCP servers."""
@@ -217,11 +240,12 @@ class TestCapabilityRegistry:
         """Test getting tools that support resources."""
         tools = get_supported_tools_for_component(ComponentType.RESOURCE)
 
-        # Cursor, Claude, and Windsurf support resources (not Copilot)
-        assert len(tools) == 3
+        # Cursor, Claude, Windsurf, and Kiro support resources (not Copilot)
+        assert len(tools) == 4
         assert AIToolType.CURSOR in tools
         assert AIToolType.CLAUDE in tools
         assert AIToolType.WINSURF in tools
+        assert AIToolType.KIRO in tools
         assert AIToolType.COPILOT not in tools  # Instructions only
 
     def test_validate_component_support_true(self) -> None:

--- a/tests/unit/test_ai_tools_detector.py
+++ b/tests/unit/test_ai_tools_detector.py
@@ -25,6 +25,7 @@ def mock_all_tools_installed(monkeypatch, temp_dir):
         (home_dir / "AppData" / "Roaming" / "Cursor" / "User" / "globalStorage").mkdir(parents=True)
         (home_dir / "AppData" / "Roaming" / "Code" / "User" / "globalStorage" / "github.copilot").mkdir(parents=True)
         (home_dir / "AppData" / "Roaming" / "Windsurf" / "User" / "globalStorage").mkdir(parents=True)
+        (home_dir / "AppData" / "Roaming" / "Kiro" / "User" / "globalStorage").mkdir(parents=True)
     elif os.name == "posix":
         if "darwin" in os.uname().sysname.lower():  # macOS
             (home_dir / "Library" / "Application Support" / "Cursor" / "User" / "globalStorage").mkdir(parents=True)
@@ -32,10 +33,12 @@ def mock_all_tools_installed(monkeypatch, temp_dir):
                 parents=True
             )
             (home_dir / "Library" / "Application Support" / "Windsurf" / "User" / "globalStorage").mkdir(parents=True)
+            (home_dir / "Library" / "Application Support" / "Kiro" / "User" / "globalStorage").mkdir(parents=True)
         else:  # Linux
             (home_dir / ".config" / "Cursor" / "User" / "globalStorage").mkdir(parents=True)
             (home_dir / ".config" / "Code" / "User" / "globalStorage" / "github.copilot").mkdir(parents=True)
             (home_dir / ".config" / "Windsurf" / "User" / "globalStorage").mkdir(parents=True)
+            (home_dir / ".config" / "Kiro" / "User" / "globalStorage").mkdir(parents=True)
     else:
         raise OSError(f"Unsupported operating system: {os.name}")
 
@@ -50,11 +53,12 @@ class TestAIToolDetector:
 
     def test_init_creates_all_tools(self, detector):
         """Test that detector initializes with all supported tools."""
-        assert len(detector.tools) == 4
+        assert len(detector.tools) == 5
         assert AIToolType.CURSOR in detector.tools
         assert AIToolType.COPILOT in detector.tools
         assert AIToolType.WINSURF in detector.tools
         assert AIToolType.CLAUDE in detector.tools
+        assert AIToolType.KIRO in detector.tools
 
     def test_detect_installed_tools_none(self, temp_dir, monkeypatch):
         """Test detect_installed_tools when no tools are installed."""
@@ -72,7 +76,7 @@ class TestAIToolDetector:
         # Create fresh detector with mocked paths
         detector = AIToolDetector()
         installed = detector.detect_installed_tools()
-        assert len(installed) == 4
+        assert len(installed) == 5
 
     def test_get_tool_by_name_valid(self, detector):
         """Test get_tool_by_name with valid tool name."""
@@ -161,11 +165,12 @@ class TestAIToolDetector:
     def test_get_tool_names(self, detector):
         """Test get_tool_names returns all tool names."""
         names = detector.get_tool_names()
-        assert len(names) == 4
+        assert len(names) == 5
         assert "cursor" in names
         assert "copilot" in names
         assert "winsurf" in names
         assert "claude" in names
+        assert "kiro" in names
 
     def test_validate_tool_name_valid(self, detector):
         """Test validate_tool_name with valid name."""
@@ -180,7 +185,7 @@ class TestAIToolDetector:
         """Test get_detection_summary."""
         detector = AIToolDetector()
         summary = detector.get_detection_summary()
-        assert len(summary) == 4
+        assert len(summary) == 5
         assert all(isinstance(v, bool) for v in summary.values())
 
     def test_format_detection_summary(self, mock_all_tools_installed):

--- a/tests/unit/test_ai_tools_kiro.py
+++ b/tests/unit/test_ai_tools_kiro.py
@@ -1,0 +1,117 @@
+"""Tests for Kiro AI tool integration."""
+
+import pytest
+
+from aiconfigkit.ai_tools.kiro import KiroTool
+from aiconfigkit.core.models import AIToolType, InstallationScope, Instruction
+
+
+@pytest.fixture
+def kiro_tool():
+    """Create a Kiro tool instance."""
+    return KiroTool()
+
+
+@pytest.fixture
+def mock_kiro_installed(monkeypatch, temp_dir):
+    """Mock Kiro as installed."""
+    import os
+
+    home_dir = temp_dir / "home"
+    home_dir.mkdir(parents=True)
+
+    # Create platform-specific directory structure
+    if os.name == "nt":  # Windows
+        kiro_dir = home_dir / "AppData" / "Roaming" / "Kiro" / "User" / "globalStorage"
+    elif os.name == "posix":
+        if "darwin" in os.uname().sysname.lower():  # macOS
+            kiro_dir = home_dir / "Library" / "Application Support" / "Kiro" / "User" / "globalStorage"
+        else:  # Linux
+            kiro_dir = home_dir / ".config" / "Kiro" / "User" / "globalStorage"
+    else:
+        raise OSError(f"Unsupported operating system: {os.name}")
+
+    kiro_dir.mkdir(parents=True)
+
+    monkeypatch.setattr("aiconfigkit.utils.paths.get_home_directory", lambda: home_dir)
+    return kiro_dir
+
+
+class TestKiroTool:
+    """Test suite for KiroTool."""
+
+    def test_tool_type(self, kiro_tool):
+        """Test tool type property."""
+        assert kiro_tool.tool_type == AIToolType.KIRO
+
+    def test_tool_name(self, kiro_tool):
+        """Test tool name property."""
+        assert kiro_tool.tool_name == "Kiro"
+
+    def test_is_installed_when_present(self, kiro_tool, mock_kiro_installed):
+        """Test is_installed returns True when Kiro is present."""
+        assert kiro_tool.is_installed() is True
+
+    def test_is_installed_when_absent(self, temp_dir, monkeypatch):
+        """Test is_installed returns False when Kiro is not present."""
+        home_dir = temp_dir / "empty_home"
+        home_dir.mkdir()
+        monkeypatch.setattr("aiconfigkit.utils.paths.get_home_directory", lambda: home_dir)
+        kiro_tool = KiroTool()
+        assert kiro_tool.is_installed() is False
+
+    def test_is_installed_handles_exception(self, monkeypatch):
+        """Test is_installed handles exceptions gracefully."""
+
+        def raise_error():
+            raise RuntimeError("Test error")
+
+        monkeypatch.setattr("aiconfigkit.utils.paths.get_home_directory", raise_error)
+        kiro_tool = KiroTool()
+        assert kiro_tool.is_installed() is False
+
+    def test_get_instructions_directory_raises_not_implemented(self, kiro_tool):
+        """Test get_instructions_directory raises NotImplementedError."""
+        with pytest.raises(NotImplementedError) as exc_info:
+            kiro_tool.get_instructions_directory()
+
+        assert "global installation is not supported" in str(exc_info.value).lower()
+
+    def test_get_instruction_file_extension(self, kiro_tool):
+        """Test instruction file extension."""
+        assert kiro_tool.get_instruction_file_extension() == ".md"
+
+    def test_get_project_instructions_directory(self, kiro_tool, temp_dir):
+        """Test project instructions directory."""
+        project_root = temp_dir / "project"
+        project_root.mkdir()
+
+        instructions_dir = kiro_tool.get_project_instructions_directory(project_root)
+
+        assert instructions_dir == project_root / ".kiro" / "steering"
+        assert instructions_dir.exists()
+
+    def test_install_instruction(self, kiro_tool, temp_dir):
+        """Test install_instruction."""
+        project_root = temp_dir / "project"
+        project_root.mkdir()
+
+        instruction = Instruction(
+            name="test-instruction",
+            description="Test",
+            content="Test content",
+            file_path="test.md",
+            tags=[],
+        )
+
+        path = kiro_tool.install_instruction(instruction, scope=InstallationScope.PROJECT, project_root=project_root)
+
+        assert path.exists()
+        assert path.read_text() == "Test content"
+        assert path.suffix == ".md"
+
+    def test_repr(self, kiro_tool):
+        """Test string representation."""
+        repr_str = repr(kiro_tool)
+        assert "KiroTool" in repr_str
+        assert AIToolType.KIRO.value in repr_str


### PR DESCRIPTION
## Summary

- Add support for Amazon's Kiro AI-powered IDE (`.kiro/steering/*.md`)
- Cross-platform detection (macOS, Linux, Windows)
- Package system support (instructions + resources)
- Full test coverage (10 new tests, all existing tests updated)

Closes #29

## Changes

**New files:**
- `aiconfigkit/ai_tools/kiro.py` — KiroTool class
- `tests/unit/test_ai_tools_kiro.py` — unit tests

**Modified:**
- `aiconfigkit/core/models.py` — `KIRO` enum value + valid_ides
- `aiconfigkit/utils/paths.py` — `get_kiro_config_dir()`
- `aiconfigkit/ai_tools/detector.py` — register + priority list
- `aiconfigkit/ai_tools/capability_registry.py` — Kiro capabilities
- `aiconfigkit/core/component_detector.py` — `.kiro/steering` detection
- `README.md`, `CLAUDE.md`, `CHANGELOG.md`, `pyproject.toml` — docs + version bump to 0.5.1

## Test plan

- [x] All 1351 unit tests pass (0 failures)
- [x] `invoke quality` passes (lint, format, typecheck)
- [x] `invoke release-check` passes
- [x] Kiro tool tests: detection, installation, extension, project directory