### PR TITLE
feat: add Cline IDE support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-02-13
+
+### Added
+- **Cline IDE Support** - Added support for the Cline VS Code extension (#31)
+  - Instructions installed to `.clinerules/*.md`
+  - Cross-platform detection via VS Code globalStorage (`saoudrizwan.claude-dev`)
+  - Package system support for instructions and resources
+  - IDE capability registry entry for Cline
+  - Component detector recognizes `.clinerules/` directories
+
 ## [0.5.1] - 2026-02-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ ai-config-kit/
 │   ├── base.py       # Abstract AITool base class
 │   ├── claude.py     # Claude Code (.claude/rules/*.md)
 │   ├── cursor.py     # Cursor (.cursor/rules/*.mdc)
+│   ├── cline.py      # Cline (.clinerules/*.md)
 │   ├── kiro.py       # Kiro (.kiro/steering/*.md)
 │   ├── winsurf.py    # Windsurf (.windsurf/rules/*.md)
 │   ├── copilot.py    # GitHub Copilot (.github/instructions/*.md)
@@ -392,6 +393,7 @@ aiconfig package uninstall package-name --yes
 #### IDE Capability Filtering
 Different IDEs support different component types:
 - **Claude Code**: All components (instructions, MCP, hooks, commands, resources)
+- **Cline**: Instructions and resources only
 - **Cursor**: Instructions and resources only
 - **Kiro**: Instructions and resources only
 - **Windsurf**: Instructions and resources only
@@ -402,6 +404,7 @@ Unsupported components are automatically skipped and counted separately.
 #### Component Translation
 Components are translated to IDE-specific formats:
 - **Claude Code**: `.md` files in `.claude/rules/`, `.claude/hooks/`, `.claude/commands/`
+- **Cline**: `.md` files in `.clinerules/`
 - **Cursor**: `.mdc` files in `.cursor/rules/`
 - **Kiro**: `.md` files in `.kiro/steering/`
 - **Windsurf**: `.md` files in `.windsurf/rules/`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Works with:** Claude Code • Claude Desktop • Cursor • GitHub Copilot • Kiro • Windsurf
+**Works with:** Claude Code • Claude Desktop • Cline • Cursor • GitHub Copilot • Kiro • Windsurf
 
 </div>
 
@@ -258,16 +258,16 @@ Any IDE-specific content from Git repositories:
 
 Complete configuration bundles with multiple component types:
 
-| Component | Claude | Cursor | Kiro | Windsurf | Copilot |
-|-----------|--------|--------|------|----------|---------|
-| Instructions | `.claude/rules/` | `.cursor/rules/` | `.kiro/steering/` | `.windsurf/rules/` | `.github/instructions/` |
-| MCP Servers | ✅ | ✅ | ❌ | ✅ | ✅ |
-| Hooks | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Commands | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Skills | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Workflows | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Memory Files | ✅ (CLAUDE.md) | ❌ | ❌ | ❌ | ❌ |
-| Resources | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Component | Claude | Cline | Cursor | Kiro | Windsurf | Copilot |
+|-----------|--------|-------|--------|------|----------|---------|
+| Instructions | `.claude/rules/` | `.clinerules/` | `.cursor/rules/` | `.kiro/steering/` | `.windsurf/rules/` | `.github/instructions/` |
+| MCP Servers | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
+| Hooks | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Commands | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Skills | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Workflows | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Memory Files | ✅ (CLAUDE.md) | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Resources | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 
 ### MCP Server Configurations
 
@@ -287,7 +287,7 @@ Model Context Protocol server setups for enhanced AI capabilities:
 
 - Python 3.10 or higher
 - Git (for cloning template repositories)
-- One of: Claude Code, Claude Desktop, Cursor, GitHub Copilot, Kiro, or Windsurf
+- One of: Claude Code, Claude Desktop, Cline, Cursor, GitHub Copilot, Kiro, or Windsurf
 
 ### Install AI Config Kit
 

--- a/aiconfigkit/ai_tools/base.py
+++ b/aiconfigkit/ai_tools/base.py
@@ -12,7 +12,7 @@ class AITool(ABC):
     """
     Abstract base class for AI coding tool integrations.
 
-    Each AI tool (Cursor, Copilot, Kiro, Winsurf, Claude) implements this interface
+    Each AI tool (Cline, Cursor, Copilot, Kiro, Winsurf, Claude) implements this interface
     to provide tool-specific installation logic.
     """
 

--- a/aiconfigkit/ai_tools/capability_registry.py
+++ b/aiconfigkit/ai_tools/capability_registry.py
@@ -142,6 +142,27 @@ CAPABILITY_REGISTRY: dict[AIToolType, IDECapability] = {
             "MCP and hooks support deferred to future release."
         ),
     ),
+    AIToolType.CLINE: IDECapability(
+        tool_type=AIToolType.CLINE,
+        tool_name="Cline",
+        supported_components={
+            ComponentType.INSTRUCTION,
+            ComponentType.RESOURCE,
+        },
+        instructions_directory=".clinerules/",
+        instruction_file_extension=".md",
+        supports_project_scope=True,
+        supports_global_scope=False,
+        mcp_config_path=None,  # Cline MCP is global-only via cline_mcp_settings.json in VS Code globalStorage
+        mcp_project_config_path=None,
+        hooks_directory=None,
+        commands_directory=None,
+        notes=(
+            "Cline uses .md files in .clinerules/ directory (recursive). "
+            "Supports optional YAML frontmatter with paths: for conditional activation. "
+            "MCP configured globally via cline_mcp_settings.json, no project-level MCP support."
+        ),
+    ),
     AIToolType.COPILOT: IDECapability(
         tool_type=AIToolType.COPILOT,
         tool_name="GitHub Copilot",

--- a/aiconfigkit/ai_tools/cline.py
+++ b/aiconfigkit/ai_tools/cline.py
@@ -1,0 +1,92 @@
+"""Cline AI tool integration."""
+
+from pathlib import Path
+
+from aiconfigkit.ai_tools.base import AITool
+from aiconfigkit.core.models import AIToolType
+from aiconfigkit.utils.paths import get_cline_config_dir
+
+
+class ClineTool(AITool):
+    """Integration for Cline AI coding tool (VS Code extension).
+
+    Cline uses .clinerules/ directory at the project root for AI instructions.
+    Files are .md (Markdown) and are read recursively. Optional YAML frontmatter
+    with `paths:` field enables conditional rule activation based on file globs.
+
+    Detection is based on the VS Code extension saoudrizwan.claude-dev
+    globalStorage directory.
+    """
+
+    @property
+    def tool_type(self) -> AIToolType:
+        """Return the AI tool type identifier."""
+        return AIToolType.CLINE
+
+    @property
+    def tool_name(self) -> str:
+        """Return human-readable tool name."""
+        return "Cline"
+
+    def is_installed(self) -> bool:
+        """
+        Check if Cline is installed on the system.
+
+        Checks for existence of the Cline VS Code extension globalStorage directory
+        (saoudrizwan.claude-dev).
+
+        Returns:
+            True if Cline is detected
+        """
+        try:
+            config_dir = get_cline_config_dir()
+            return config_dir.exists()
+        except Exception:
+            return False
+
+    def get_instructions_directory(self) -> Path:
+        """
+        Get the directory where Cline instructions should be installed.
+
+        Note: Cline global rules live in ~/Documents/Cline/Rules/ but this
+        is non-standard. This tool only supports project-level installations.
+
+        Returns:
+            Path to Cline instructions directory
+
+        Raises:
+            NotImplementedError: Global installation not supported for Cline
+        """
+        raise NotImplementedError(
+            f"{self.tool_name} global installation is not supported. "
+            "Please use project-level installation instead (--scope project)."
+        )
+
+    def get_instruction_file_extension(self) -> str:
+        """
+        Get the file extension for Cline instructions.
+
+        Cline uses markdown (.md) files in the .clinerules/ directory.
+
+        Returns:
+            File extension including the dot
+        """
+        return ".md"
+
+    def get_project_instructions_directory(self, project_root: Path) -> Path:
+        """
+        Get the directory for project-specific Cline instructions.
+
+        Cline stores project-specific rules in .clinerules/ directory at the
+        project root. It reads .md files recursively from this directory.
+        Numeric prefixes (e.g., 01-coding-standards.md) control load order.
+
+        Args:
+            project_root: Path to the project root directory
+
+        Returns:
+            Path to project instructions directory (.clinerules/)
+        """
+        instructions_dir = project_root / ".clinerules"
+        instructions_dir.mkdir(parents=True, exist_ok=True)
+        return instructions_dir

--- a/aiconfigkit/ai_tools/detector.py
+++ b/aiconfigkit/ai_tools/detector.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from aiconfigkit.ai_tools.base import AITool
 from aiconfigkit.ai_tools.claude import ClaudeTool
+from aiconfigkit.ai_tools.cline import ClineTool
 from aiconfigkit.ai_tools.copilot import CopilotTool
 from aiconfigkit.ai_tools.cursor import CursorTool
 from aiconfigkit.ai_tools.kiro import KiroTool
@@ -22,6 +23,7 @@ class AIToolDetector:
             AIToolType.WINSURF: WinsurfTool(),
             AIToolType.CLAUDE: ClaudeTool(),
             AIToolType.KIRO: KiroTool(),
+            AIToolType.CLINE: ClineTool(),
         }
 
     def detect_installed_tools(self) -> list[AITool]:
@@ -81,6 +83,7 @@ class AIToolDetector:
             AIToolType.WINSURF,
             AIToolType.CLAUDE,
             AIToolType.KIRO,
+            AIToolType.CLINE,
         ]
 
         for tool_type in priority:

--- a/aiconfigkit/core/component_detector.py
+++ b/aiconfigkit/core/component_detector.py
@@ -233,6 +233,7 @@ class ComponentDetector:
         ".cursor/rules": "cursor",
         ".windsurf/rules": "windsurf",
         ".kiro/steering": "kiro",
+        ".clinerules": "cline",
         ".github/instructions": "copilot",
     }
 

--- a/aiconfigkit/core/models.py
+++ b/aiconfigkit/core/models.py
@@ -14,6 +14,7 @@ class AIToolType(Enum):
     WINSURF = "winsurf"
     CLAUDE = "claude"
     KIRO = "kiro"
+    CLINE = "cline"
 
 
 class ConflictResolution(Enum):
@@ -404,7 +405,7 @@ class TemplateFile:
 
     Attributes:
         path: Relative path from repository root
-        ide: Target IDE ("all", "cursor", "claude", "windsurf", "copilot", "kiro")
+        ide: Target IDE ("all", "cursor", "claude", "windsurf", "copilot", "kiro", "cline")
     """
 
     path: str
@@ -414,7 +415,7 @@ class TemplateFile:
         """Validate template file data."""
         if not self.path:
             raise ValueError("Template file path cannot be empty")
-        valid_ides = ["all", "cursor", "claude", "windsurf", "copilot", "kiro"]
+        valid_ides = ["all", "cursor", "claude", "windsurf", "copilot", "kiro", "cline"]
         if self.ide not in valid_ides:
             raise ValueError(f"Invalid IDE type: {self.ide}. Must be one of {valid_ides}")
 

--- a/aiconfigkit/utils/paths.py
+++ b/aiconfigkit/utils/paths.py
@@ -70,6 +70,23 @@ def get_kiro_config_dir() -> Path:
     raise OSError(f"Unsupported operating system: {os.name}")
 
 
+def get_cline_config_dir() -> Path:
+    """Get Cline (VS Code extension) configuration directory based on platform."""
+    home = get_home_directory()
+
+    if os.name == "nt":  # Windows
+        return home / "AppData" / "Roaming" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev"
+    elif os.name == "posix":
+        if "darwin" in os.uname().sysname.lower():  # macOS
+            return (
+                home / "Library" / "Application Support" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev"
+            )
+        else:  # Linux
+            return home / ".config" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev"
+
+    raise OSError(f"Unsupported operating system: {os.name}")
+
+
 def get_claude_config_dir() -> Path:
     """Get Claude Code configuration directory based on platform."""
     home = get_home_directory()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ai-config-kit"
-version = "0.5.1"
+version = "0.5.2"
 description = "Distribute and sync AI coding assistant configurations across teams"
 readme = "README.md"
 authors = [{ name = "Troy Larson", email = "troy@calvinware.com" }]
 requires-python = ">=3.10"
 license = { text = "MIT License" }
-keywords = ["cli", "ai", "config", "mcp", "cursor", "copilot", "claude", "kiro", "windsurf"]
+keywords = ["cli", "ai", "config", "mcp", "cursor", "copilot", "claude", "cline", "kiro", "windsurf"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/tests/unit/packages/test_capability_registry.py
+++ b/tests/unit/packages/test_capability_registry.py
@@ -68,6 +68,7 @@ class TestCapabilityRegistry:
         assert AIToolType.WINSURF in CAPABILITY_REGISTRY
         assert AIToolType.COPILOT in CAPABILITY_REGISTRY
         assert AIToolType.KIRO in CAPABILITY_REGISTRY
+        assert AIToolType.CLINE in CAPABILITY_REGISTRY
 
     def test_cursor_capabilities(self) -> None:
         """Test Cursor IDE capabilities."""
@@ -197,17 +198,39 @@ class TestCapabilityRegistry:
         assert not kiro.supports_component(ComponentType.MCP_SERVER)
         assert not kiro.supports_component(ComponentType.SKILL)
 
+    def test_cline_capabilities(self) -> None:
+        """Test Cline IDE capabilities."""
+        cline = CAPABILITY_REGISTRY[AIToolType.CLINE]
+
+        assert cline.tool_type == AIToolType.CLINE
+        assert cline.tool_name == "Cline"
+        assert cline.instructions_directory == ".clinerules/"
+        assert cline.instruction_file_extension == ".md"
+        assert cline.supports_project_scope
+        assert not cline.supports_global_scope
+
+        # Cline supports instructions and resources
+        assert cline.supports_component(ComponentType.INSTRUCTION)
+        assert cline.supports_component(ComponentType.RESOURCE)
+
+        # Cline does not support hooks, commands, MCP, or skills
+        assert not cline.supports_component(ComponentType.HOOK)
+        assert not cline.supports_component(ComponentType.COMMAND)
+        assert not cline.supports_component(ComponentType.MCP_SERVER)
+        assert not cline.supports_component(ComponentType.SKILL)
+
     def test_get_supported_tools_for_instruction(self) -> None:
         """Test getting tools that support instructions."""
         tools = get_supported_tools_for_component(ComponentType.INSTRUCTION)
 
         # All tools support instructions
-        assert len(tools) == 5
+        assert len(tools) == 6
         assert AIToolType.CURSOR in tools
         assert AIToolType.CLAUDE in tools
         assert AIToolType.WINSURF in tools
         assert AIToolType.COPILOT in tools
         assert AIToolType.KIRO in tools
+        assert AIToolType.CLINE in tools
 
     def test_get_supported_tools_for_mcp_server(self) -> None:
         """Test getting tools that support MCP servers."""
@@ -240,12 +263,13 @@ class TestCapabilityRegistry:
         """Test getting tools that support resources."""
         tools = get_supported_tools_for_component(ComponentType.RESOURCE)
 
-        # Cursor, Claude, Windsurf, and Kiro support resources (not Copilot)
-        assert len(tools) == 4
+        # Cursor, Claude, Windsurf, Kiro, and Cline support resources (not Copilot)
+        assert len(tools) == 5
         assert AIToolType.CURSOR in tools
         assert AIToolType.CLAUDE in tools
         assert AIToolType.WINSURF in tools
         assert AIToolType.KIRO in tools
+        assert AIToolType.CLINE in tools
         assert AIToolType.COPILOT not in tools  # Instructions only
 
     def test_validate_component_support_true(self) -> None:

--- a/tests/unit/test_ai_tools_cline.py
+++ b/tests/unit/test_ai_tools_cline.py
@@ -1,0 +1,126 @@
+"""Tests for Cline AI tool integration."""
+
+import pytest
+
+from aiconfigkit.ai_tools.cline import ClineTool
+from aiconfigkit.core.models import AIToolType, InstallationScope, Instruction
+
+
+@pytest.fixture
+def cline_tool():
+    """Create a Cline tool instance."""
+    return ClineTool()
+
+
+@pytest.fixture
+def mock_cline_installed(monkeypatch, temp_dir):
+    """Mock Cline as installed."""
+    import os
+
+    home_dir = temp_dir / "home"
+    home_dir.mkdir(parents=True)
+
+    # Cline is a VS Code extension — detection uses globalStorage path
+    if os.name == "nt":  # Windows
+        cline_dir = home_dir / "AppData" / "Roaming" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev"
+    elif os.name == "posix":
+        if "darwin" in os.uname().sysname.lower():  # macOS
+            cline_dir = (
+                home_dir
+                / "Library"
+                / "Application Support"
+                / "Code"
+                / "User"
+                / "globalStorage"
+                / "saoudrizwan.claude-dev"
+            )
+        else:  # Linux
+            cline_dir = home_dir / ".config" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev"
+    else:
+        raise OSError(f"Unsupported operating system: {os.name}")
+
+    cline_dir.mkdir(parents=True)
+
+    monkeypatch.setattr("aiconfigkit.utils.paths.get_home_directory", lambda: home_dir)
+    return cline_dir
+
+
+class TestClineTool:
+    """Test suite for ClineTool."""
+
+    def test_tool_type(self, cline_tool):
+        """Test tool type property."""
+        assert cline_tool.tool_type == AIToolType.CLINE
+
+    def test_tool_name(self, cline_tool):
+        """Test tool name property."""
+        assert cline_tool.tool_name == "Cline"
+
+    def test_is_installed_when_present(self, cline_tool, mock_cline_installed):
+        """Test is_installed returns True when Cline is present."""
+        assert cline_tool.is_installed() is True
+
+    def test_is_installed_when_absent(self, temp_dir, monkeypatch):
+        """Test is_installed returns False when Cline is not present."""
+        home_dir = temp_dir / "empty_home"
+        home_dir.mkdir()
+        monkeypatch.setattr("aiconfigkit.utils.paths.get_home_directory", lambda: home_dir)
+        cline_tool = ClineTool()
+        assert cline_tool.is_installed() is False
+
+    def test_is_installed_handles_exception(self, monkeypatch):
+        """Test is_installed handles exceptions gracefully."""
+
+        def raise_error():
+            raise RuntimeError("Test error")
+
+        monkeypatch.setattr("aiconfigkit.utils.paths.get_home_directory", raise_error)
+        cline_tool = ClineTool()
+        assert cline_tool.is_installed() is False
+
+    def test_get_instructions_directory_raises_not_implemented(self, cline_tool):
+        """Test get_instructions_directory raises NotImplementedError."""
+        with pytest.raises(NotImplementedError) as exc_info:
+            cline_tool.get_instructions_directory()
+
+        assert "global installation is not supported" in str(exc_info.value).lower()
+
+    def test_get_instruction_file_extension(self, cline_tool):
+        """Test instruction file extension."""
+        assert cline_tool.get_instruction_file_extension() == ".md"
+
+    def test_get_project_instructions_directory(self, cline_tool, temp_dir):
+        """Test project instructions directory uses .clinerules/."""
+        project_root = temp_dir / "project"
+        project_root.mkdir()
+
+        instructions_dir = cline_tool.get_project_instructions_directory(project_root)
+
+        assert instructions_dir == project_root / ".clinerules"
+        assert instructions_dir.exists()
+
+    def test_install_instruction(self, cline_tool, temp_dir):
+        """Test install_instruction creates .md file in .clinerules/."""
+        project_root = temp_dir / "project"
+        project_root.mkdir()
+
+        instruction = Instruction(
+            name="test-instruction",
+            description="Test",
+            content="Test content",
+            file_path="test.md",
+            tags=[],
+        )
+
+        path = cline_tool.install_instruction(instruction, scope=InstallationScope.PROJECT, project_root=project_root)
+
+        assert path.exists()
+        assert path.read_text() == "Test content"
+        assert path.suffix == ".md"
+        assert ".clinerules" in str(path)
+
+    def test_repr(self, cline_tool):
+        """Test string representation."""
+        repr_str = repr(cline_tool)
+        assert "ClineTool" in repr_str
+        assert AIToolType.CLINE.value in repr_str

--- a/tests/unit/test_ai_tools_detector.py
+++ b/tests/unit/test_ai_tools_detector.py
@@ -26,6 +26,9 @@ def mock_all_tools_installed(monkeypatch, temp_dir):
         (home_dir / "AppData" / "Roaming" / "Code" / "User" / "globalStorage" / "github.copilot").mkdir(parents=True)
         (home_dir / "AppData" / "Roaming" / "Windsurf" / "User" / "globalStorage").mkdir(parents=True)
         (home_dir / "AppData" / "Roaming" / "Kiro" / "User" / "globalStorage").mkdir(parents=True)
+        (home_dir / "AppData" / "Roaming" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev").mkdir(
+            parents=True
+        )
     elif os.name == "posix":
         if "darwin" in os.uname().sysname.lower():  # macOS
             (home_dir / "Library" / "Application Support" / "Cursor" / "User" / "globalStorage").mkdir(parents=True)
@@ -34,11 +37,22 @@ def mock_all_tools_installed(monkeypatch, temp_dir):
             )
             (home_dir / "Library" / "Application Support" / "Windsurf" / "User" / "globalStorage").mkdir(parents=True)
             (home_dir / "Library" / "Application Support" / "Kiro" / "User" / "globalStorage").mkdir(parents=True)
+            cline_dir = (
+                home_dir
+                / "Library"
+                / "Application Support"
+                / "Code"
+                / "User"
+                / "globalStorage"
+                / "saoudrizwan.claude-dev"
+            )
+            cline_dir.mkdir(parents=True)
         else:  # Linux
             (home_dir / ".config" / "Cursor" / "User" / "globalStorage").mkdir(parents=True)
             (home_dir / ".config" / "Code" / "User" / "globalStorage" / "github.copilot").mkdir(parents=True)
             (home_dir / ".config" / "Windsurf" / "User" / "globalStorage").mkdir(parents=True)
             (home_dir / ".config" / "Kiro" / "User" / "globalStorage").mkdir(parents=True)
+            (home_dir / ".config" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev").mkdir(parents=True)
     else:
         raise OSError(f"Unsupported operating system: {os.name}")
 
@@ -53,12 +67,13 @@ class TestAIToolDetector:
 
     def test_init_creates_all_tools(self, detector):
         """Test that detector initializes with all supported tools."""
-        assert len(detector.tools) == 5
+        assert len(detector.tools) == 6
         assert AIToolType.CURSOR in detector.tools
         assert AIToolType.COPILOT in detector.tools
         assert AIToolType.WINSURF in detector.tools
         assert AIToolType.CLAUDE in detector.tools
         assert AIToolType.KIRO in detector.tools
+        assert AIToolType.CLINE in detector.tools
 
     def test_detect_installed_tools_none(self, temp_dir, monkeypatch):
         """Test detect_installed_tools when no tools are installed."""
@@ -76,7 +91,7 @@ class TestAIToolDetector:
         # Create fresh detector with mocked paths
         detector = AIToolDetector()
         installed = detector.detect_installed_tools()
-        assert len(installed) == 5
+        assert len(installed) == 6
 
     def test_get_tool_by_name_valid(self, detector):
         """Test get_tool_by_name with valid tool name."""
@@ -165,12 +180,13 @@ class TestAIToolDetector:
     def test_get_tool_names(self, detector):
         """Test get_tool_names returns all tool names."""
         names = detector.get_tool_names()
-        assert len(names) == 5
+        assert len(names) == 6
         assert "cursor" in names
         assert "copilot" in names
         assert "winsurf" in names
         assert "claude" in names
         assert "kiro" in names
+        assert "cline" in names
 
     def test_validate_tool_name_valid(self, detector):
         """Test validate_tool_name with valid name."""
@@ -185,7 +201,7 @@ class TestAIToolDetector:
         """Test get_detection_summary."""
         detector = AIToolDetector()
         summary = detector.get_detection_summary()
-        assert len(summary) == 5
+        assert len(summary) == 6
         assert all(isinstance(v, bool) for v in summary.values())
 
     def test_format_detection_summary(self, mock_all_tools_installed):


### PR DESCRIPTION
## Summary

- Adds full Cline VS Code extension support (`saoudrizwan.claude-dev`)
- Instructions installed to `.clinerules/*.md` with project-level scope
- Cross-platform detection via VS Code globalStorage directory (macOS, Linux, Windows)
- IDE capability registry entry for instructions and resources
- Component detector recognizes `.clinerules/` directories

Closes #31

## Test plan

- [x] All 1531 tests pass
- [x] Quality checks pass (lint, format, typecheck)
- [x] Cline tool type, name, detection, instruction paths all tested
- [x] Detector and capability registry counts updated for 6 tools