### PR TITLE
chore: update all dependencies (#84)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
     name: Run Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: Code Quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -49,7 +49,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -77,7 +77,7 @@ jobs:
     name: Security Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -13,7 +13,7 @@ jobs:
     name: Coverage Report
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
     name: Code Complexity Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -79,7 +79,7 @@ jobs:
     name: Diff Quality Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -103,7 +103,7 @@ jobs:
 
       - name: Comment on PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -14,7 +14,7 @@ jobs:
     name: Auto-label PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -68,7 +68,7 @@ jobs:
 
       - name: Comment if tests are missing
         if: steps.code_changes.outputs.has_code_changes == 'true' && steps.test_changes.outputs.has_test_changes == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({
@@ -84,12 +84,12 @@ jobs:
   #   runs-on: ubuntu-latest
   #   if: github.event_name == 'pull_request'
   #   steps:
-  #     - uses: actions/checkout@v5
+  #     - uses: actions/checkout@v6
   #       with:
   #         fetch-depth: 0
   #
   #     - name: Check PR title
-  #       uses: amannn/action-semantic-pull-request@v5
+  #       uses: amannn/action-semantic-pull-request@v6
   #       env:
   #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   #       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Run Release Drafter
         uses: release-drafter/release-drafter@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<69", "wheel"]
+requires = ["setuptools<81", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -35,7 +35,7 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "pytest-cov>=5.0.0",
-    "black==24.10.0",
+    "black==26.1.0",
     "mypy>=1.10.0",
     "ruff>=0.9.0",
     "invoke>=2.0.0",

--- a/tests/unit/packages/test_component_detector.py
+++ b/tests/unit/packages/test_component_detector.py
@@ -396,15 +396,13 @@ class TestSkillDetection:
         skills_dir = temp_project / ".claude" / "skills"
         skill_dir = skills_dir / "my-skill"
         skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text(
-            """---
+        (skill_dir / "SKILL.md").write_text("""---
 name: my-skill
 description: A test skill
 ---
 # My Skill
 Instructions for the skill.
-"""
-        )
+""")
 
         detector = ComponentDetector(temp_project)
         result = detector.detect_all()
@@ -448,14 +446,12 @@ class TestWorkflowDetection:
         """Test detection of workflow file."""
         workflows_dir = temp_project / ".windsurf" / "workflows"
         workflows_dir.mkdir(parents=True)
-        (workflows_dir / "deploy.md").write_text(
-            """---
+        (workflows_dir / "deploy.md").write_text("""---
 description: Deploy workflow
 ---
 # Deploy Workflow
 Steps for deployment.
-"""
-        )
+""")
 
         detector = ComponentDetector(temp_project)
         result = detector.detect_all()


### PR DESCRIPTION
## Summary

- Consolidates all 6 open Dependabot PRs into a single update
- Updates GitHub Actions and Python dev dependencies to latest versions
- Applies black 26.1.0 reformatting (1 file changed)

## Changes

### GitHub Actions (CI workflows)
- `actions/checkout` v5 → v6 (13 occurrences across 7 workflows)
- `actions/github-script` v7 → v8 (2 occurrences)
- `actions/labeler` v5 → v6 (1 occurrence)
- `amannn/action-semantic-pull-request` v5 → v6 (commented out section)

### Python Dependencies (pyproject.toml)
- `setuptools` build requirement: `<69` → `<81`
- `black` dev dependency: `24.10.0` → `26.1.0`

## Supersedes

Closes #20, Closes #21, Closes #22, Closes #26, Closes #27, Closes #28

## Issue References

Closes #84

## Test Plan

- [x] All 1604 unit tests pass
- [x] Lint passes (ruff)
- [x] Format passes (black 26.1.0)
- [x] Type check passes (mypy)
- [ ] CI passes on GitHub Actions with updated action versions